### PR TITLE
Answers to Search (3): Rename request, error, and core

### DIFF
--- a/src/SearchCore.ts
+++ b/src/SearchCore.ts
@@ -17,7 +17,7 @@ import { AutocompleteService } from './services/AutocompleteService';
  *
  * @public
  */
-export class AnswersCore {
+export class SearchCore {
   constructor(
     private searchService: SearchService,
     private questionSubmissionService: QuestionSubmissionService,

--- a/src/SearchCore.ts
+++ b/src/SearchCore.ts
@@ -25,10 +25,10 @@ export class SearchCore {
   ) {}
 
   /**
-   * Performs an Answers search across all verticals.
+   * Performs a search across all verticals.
    *
    * @remarks
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @param request - Universal search request options
    */
@@ -37,10 +37,10 @@ export class SearchCore {
   }
 
   /**
-   * Performs an Answers search for a single vertical.
+   * Performs a search for a single vertical.
    *
    * @remarks
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @param request - Vertical search request options
    */
@@ -49,10 +49,10 @@ export class SearchCore {
   }
 
   /**
-   * Submits a custom question to the Answers API.
+   * Submits a custom question to the Search API.
    *
    * @remarks
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @param request - Question submission request options
    */
@@ -64,7 +64,7 @@ export class SearchCore {
    * Performs an autocomplete request across all verticals.
    *
    * @remarks
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @param request - Universal autocomplete request options
    */
@@ -76,7 +76,7 @@ export class SearchCore {
    * Performs an autocomplete request for a single vertical.
    *
    * @remarks
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @param request - Vertical autocomplete request options
    */
@@ -90,7 +90,7 @@ export class SearchCore {
    * @remarks
    * This differs from the vertical autocomplete because the vertical autocomplete
    * operates on all entity fields whereas filtersearch operates only on specified fields.
-   * If rejected, the reason will be an {@link AnswersError}.
+   * If rejected, the reason will be an {@link SearchError}.
    *
    * @example
    * A site has a 'products' vertical and would like a way to allow the user to narrow down

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -1,0 +1,7 @@
+import { SearchCore } from './SearchCore';
+
+/**
+ * @deprecated AnswersCore is deprecated and has been replaced by SearchCore
+ * @public
+ */
+export class AnswersCore extends SearchCore{}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { AnswersCore } from './AnswersCore';
+// deprecated symbols
+export { AnswersCore } from './deprecated';
+
+// main symbols
+export { SearchCore } from './SearchCore';
 export { provideCore } from './provideCore';
 export { SandboxEndpoints } from './constants';
 export * from './models';

--- a/src/models/answersapi/SearchError.ts
+++ b/src/models/answersapi/SearchError.ts
@@ -2,16 +2,16 @@
  * Represents an error
  *
  * @remarks
- * If the error originates from the Answer API, the code and type property will be present.
+ * If the error originates from the Search API, the code and type property will be present.
  *
  * @public
  */
-export class AnswersError extends Error {
+export class SearchError extends Error {
   /** The error message. */
   public message: string;
-  /** Answers API error code. */
+  /** Search API error code. */
   public code?: number;
-  /** Answers API error type. */
+  /** Search API error type. */
   public type?: string;
 
   /** @internal */
@@ -25,6 +25,6 @@ export class AnswersError extends Error {
     // When targeting ES5, it is necessary to manually set the prototype for instance of checks to work
     // See: "Extending built-ins like Error, Array, and Map may no longer work"
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes
-    Object.setPrototypeOf(this, AnswersError.prototype);
+    Object.setPrototypeOf(this, SearchError.prototype);
   }
 }

--- a/src/models/autocompleteservice/AutocompleteRequest.ts
+++ b/src/models/autocompleteservice/AutocompleteRequest.ts
@@ -1,4 +1,4 @@
-import { AnswersRequest } from '../core/AnswersRequest';
+import { SearchRequest } from '../core/SearchRequest';
 import { Filter } from '../searchservice/request/Filter';
 
 /**
@@ -6,7 +6,7 @@ import { Filter } from '../searchservice/request/Filter';
  *
  * @public
  */
-export interface UniversalAutocompleteRequest extends AnswersRequest {
+export interface UniversalAutocompleteRequest extends SearchRequest {
   /** The input string for autocomplete. */
   input: string,
   /** Enables session tracking. */
@@ -18,7 +18,7 @@ export interface UniversalAutocompleteRequest extends AnswersRequest {
  *
  * @public
  */
-export interface VerticalAutocompleteRequest extends AnswersRequest {
+export interface VerticalAutocompleteRequest extends SearchRequest {
   /** {@inheritDoc UniversalAutocompleteRequest.input} */
   input: string,
   /** {@inheritDoc UniversalAutocompleteRequest.sessionTrackingEnabled} */
@@ -32,7 +32,7 @@ export interface VerticalAutocompleteRequest extends AnswersRequest {
  *
  * @public
  */
-export interface FilterSearchRequest extends AnswersRequest {
+export interface FilterSearchRequest extends SearchRequest {
   /** {@inheritDoc UniversalAutocompleteRequest.input} */
   input: string,
   /** {@inheritDoc UniversalAutocompleteRequest.sessionTrackingEnabled} */

--- a/src/models/core/SearchRequest.ts
+++ b/src/models/core/SearchRequest.ts
@@ -1,11 +1,11 @@
 import { AdditionalHttpHeaders } from './AdditionalHttpHeaders';
 
 /**
- * Options for an Answers API request.
+ * Options for an Search API request.
  *
  * @public
  */
-export interface AnswersRequest {
+export interface SearchRequest {
   /** {@inheritDoc AdditionalHttpHeaders} */
   additionalHttpHeaders?: AdditionalHttpHeaders
 }

--- a/src/models/deprecated.ts
+++ b/src/models/deprecated.ts
@@ -1,7 +1,14 @@
 import { SearchError } from './answersapi/SearchError';
+import { SearchRequest } from './core/SearchRequest';
 
 /**
  * @deprecated AnswersError is deprecated and has been replaced by SearchError
  * @public
  */
 export type AnswersError = SearchError;
+
+/**
+* @deprecated AnswersRequest is deprecated and has been replaced by SearchRequest
+* @public
+*/
+export type AnswersRequest = SearchRequest;

--- a/src/models/deprecated.ts
+++ b/src/models/deprecated.ts
@@ -1,0 +1,7 @@
+import { SearchError } from './answersapi/SearchError';
+
+/**
+ * @deprecated AnswersError is deprecated and has been replaced by SearchError
+ * @public
+ */
+export type AnswersError = SearchError;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,5 @@
 // Answers API models
-export { AnswersError } from './answersapi/AnswersError';
+export { SearchError } from './answersapi/SearchError';
 
 // Core models
 export {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 // deprecated symbols
 export { AnswersError } from './deprecated';
+export { AnswersRequest } from './deprecated';
 
 // Answers API models
 export { SearchError } from './answersapi/SearchError';
@@ -11,7 +12,7 @@ export {
   AnswersConfigWithApiKey,
   AnswersConfigWithToken
 } from './core/AnswersConfig';
-export { AnswersRequest } from './core/AnswersRequest';
+export { SearchRequest } from './core/SearchRequest';
 export { Endpoints } from './core/Endpoints';
 export { Visitor } from './core/Visitor';
 export {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,6 @@
+// deprecated symbols
+export { AnswersError } from './deprecated';
+
 // Answers API models
 export { SearchError } from './answersapi/SearchError';
 

--- a/src/models/questionsubmission/QuestionSubmissionRequest.ts
+++ b/src/models/questionsubmission/QuestionSubmissionRequest.ts
@@ -1,11 +1,11 @@
-import { AnswersRequest } from '../core/AnswersRequest';
+import { SearchRequest } from '../core/SearchRequest';
 
 /**
  * Options for a QuestionSubmission request.
  *
  * @public
  */
-export interface QuestionSubmissionRequest extends AnswersRequest {
+export interface QuestionSubmissionRequest extends SearchRequest {
   /** The email of the user that is submitting the question. */
   email: string,
   /** The ID of the entity to associate with the question. */

--- a/src/models/searchservice/request/UniversalSearchRequest.ts
+++ b/src/models/searchservice/request/UniversalSearchRequest.ts
@@ -3,14 +3,14 @@ import { LatLong } from './LatLong';
 import { QueryTrigger } from './QueryTrigger';
 import { QuerySource } from './QuerySource';
 import { UniversalLimit } from './UniversalLimit';
-import { AnswersRequest } from '../../core/AnswersRequest';
+import { SearchRequest } from '../../core/SearchRequest';
 
 /**
  * Options which can be specified for a universal search.
  *
  * @public
  */
-export interface UniversalSearchRequest extends AnswersRequest {
+export interface UniversalSearchRequest extends SearchRequest {
   /** The search query. */
   query: string,
   /** {@inheritDoc QueryTrigger} */

--- a/src/models/searchservice/request/VerticalSearchRequest.ts
+++ b/src/models/searchservice/request/VerticalSearchRequest.ts
@@ -6,14 +6,14 @@ import { QueryTrigger } from './QueryTrigger';
 import { SortBy } from './SortBy';
 import { QuerySource } from './QuerySource';
 import { Facet } from './Facet';
-import { AnswersRequest } from '../../core/AnswersRequest';
+import { SearchRequest } from '../../core/SearchRequest';
 
 /**
  * Options which can be specified for a vertical search.
  *
  * @public
  */
-export interface VerticalSearchRequest extends AnswersRequest {
+export interface VerticalSearchRequest extends SearchRequest {
   /** The search query. */
   query: string,
   /** The key associated with the vertical. */

--- a/src/provideCore.ts
+++ b/src/provideCore.ts
@@ -4,20 +4,20 @@ import { HttpServiceImpl } from './infra/HttpServiceImpl';
 import { AnswersConfig, AnswersConfigWithDefaulting } from './models/core/AnswersConfig';
 import { AutocompleteServiceImpl } from './infra/AutocompleteServiceImpl';
 import { ApiResponseValidator } from './validation/ApiResponseValidator';
-import { AnswersCore } from './AnswersCore';
+import { SearchCore } from './SearchCore';
 import { defaultEndpoints } from './constants';
 
 /**
  * The entrypoint to the answers-core library.
  *
  * @remarks
- * Returns an {@link AnswersCore} instance.
+ * Returns an {@link SearchCore} instance.
  *
  * @param config - The answers-core config
  *
  * @public
  */
-export function provideCore(config: AnswersConfig): AnswersCore {
+export function provideCore(config: AnswersConfig): SearchCore {
   if ('apiKey' in config && 'token' in config) {
     throw new Error('Both apiKey and token are present. Only one authentication method should be provided');
   }
@@ -38,5 +38,5 @@ export function provideCore(config: AnswersConfig): AnswersCore {
     defaultedConfig, httpService, apiResponseValidator);
   const autoCompleteService = new AutocompleteServiceImpl(defaultedConfig, httpService, apiResponseValidator);
 
-  return new AnswersCore(searchService, questionSubmissionService, autoCompleteService);
+  return new SearchCore(searchService, questionSubmissionService, autoCompleteService);
 }

--- a/src/transformers/autocompleteservice/createAutocompleteResponse.ts
+++ b/src/transformers/autocompleteservice/createAutocompleteResponse.ts
@@ -1,4 +1,4 @@
-import { AnswersError } from '../../models/answersapi/AnswersError';
+import { SearchError } from '../../models/answersapi/SearchError';
 import { AutocompleteResponse, FilterSearchResponse } from '../../models/autocompleteservice/AutocompleteResponse';
 import { createAutocompleteResult } from './createAutocompleteResult';
 
@@ -32,7 +32,7 @@ export function createFilterSearchResponse(data: any): FilterSearchResponse {
   const response = data.response;
   if (response.failedVerticals && response.failedVerticals.length != 0) {
     const error = response.failedVerticals[0];
-    throw new AnswersError(error.details.description, error.details.responseCode, error.errorType);
+    throw new SearchError(error.details.description, error.details.responseCode, error.errorType);
   }
   const sections = response.sections.map((section: any) => ({
     label: section.label,

--- a/src/validation/ApiResponseValidator.ts
+++ b/src/validation/ApiResponseValidator.ts
@@ -1,13 +1,13 @@
 import { ApiResponse } from '../models/answersapi/ApiResponse';
-import { AnswersError } from '../models/answersapi/AnswersError';
+import { SearchError } from '../models/answersapi/SearchError';
 
 /**
- * Determines whether or not an API response can be used to construct an answers-core response
+ * Determines whether or not an API response can be used to construct an search-core response
  *
  * @internal
  */
 export class ApiResponseValidator {
-  public validate(apiResponse: ApiResponse): AnswersError | undefined {
+  public validate(apiResponse: ApiResponse): SearchError | undefined {
     const testFunctions = [
       this.validateResponseProp,
       this.validateMetaProp,
@@ -19,22 +19,22 @@ export class ApiResponseValidator {
     return testResults.find(result => result);
   }
 
-  private validateResponseProp(apiResponse: ApiResponse): AnswersError | undefined {
+  private validateResponseProp(apiResponse: ApiResponse): SearchError | undefined {
     if (!apiResponse.response) {
-      return new AnswersError('Malformed Answers API response: missing response property.');
+      return new SearchError('Malformed Search API response: missing response property.');
     }
   }
 
-  private validateMetaProp(apiResponse: ApiResponse): AnswersError | undefined {
+  private validateMetaProp(apiResponse: ApiResponse): SearchError | undefined {
     if (!apiResponse.meta) {
-      return new AnswersError('Malformed Answers API response: missing meta property.');
+      return new SearchError('Malformed Search API response: missing meta property.');
     }
   }
 
-  private checkForApiErrors(apiResponse: ApiResponse): AnswersError | undefined {
+  private checkForApiErrors(apiResponse: ApiResponse): SearchError | undefined {
     if (apiResponse.meta?.errors?.length >= 1) {
       const error = apiResponse.meta.errors[0];
-      return new AnswersError(error.message, error.code, error.type);
+      return new SearchError(error.message, error.code, error.type);
     }
   }
 }

--- a/test-site/src/ts/index.ts
+++ b/test-site/src/ts/index.ts
@@ -1,4 +1,4 @@
-import { provideCore, AnswersConfig, AnswersCore } from '@yext/answers-core';
+import { provideCore, AnswersConfig, SearchCore } from '@yext/search-core';
 import verticalRequest from './requests/verticalRequest';
 import universalRequest from './requests/universalRequest';
 import questionRequest from './requests/questionRequest';
@@ -16,7 +16,7 @@ window.onload = () => {
   document.body.appendChild(element);
 };
 
-const globalCore: AnswersCore = provideCore(coreConfig);
+const globalCore: SearchCore = provideCore(coreConfig);
 
 export async function universalSearch(): Promise<void> {
   loadingSpinner();

--- a/tests/infra/AutocompleteServiceImpl.ts
+++ b/tests/infra/AutocompleteServiceImpl.ts
@@ -14,7 +14,7 @@ import mockAutocompleteResponseWithVerticalKeys from '../fixtures/autocompletere
 import { defaultEndpoints, defaultApiVersion } from '../../src/constants';
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
 import { ApiResponse } from '../../src/models/answersapi/ApiResponse';
-import { AnswersError } from '../../src/models/answersapi/AnswersError';
+import { SearchError } from '../../src/models/answersapi/SearchError';
 import { getClientSdk } from '../../src/utils/getClientSdk';
 import { Matcher } from '../../src/models/searchservice/common/Matcher';
 
@@ -259,7 +259,7 @@ describe('AutocompleteService', () => {
           message: 'Something went wrong.',
           code: 400,
           type: 'BACKEND_ERROR'
-        } as AnswersError);
+        } as SearchError);
     });
   });
 });

--- a/tests/provideCore.ts
+++ b/tests/provideCore.ts
@@ -5,7 +5,7 @@ import { SearchServiceImpl } from '../src/infra/SearchServiceImpl';
 import { Endpoints } from '../src/models/core/Endpoints';
 import { provideCore } from '../src/provideCore';
 
-jest.mock('../src/AnswersCore');
+jest.mock('../src/SearchCore');
 jest.mock('../src/infra/AutocompleteServiceImpl');
 jest.mock('../src/infra/QuestionSubmissionServiceImpl');
 jest.mock('../src/infra/SearchServiceImpl');

--- a/tests/validation/ApiResponseValidator.ts
+++ b/tests/validation/ApiResponseValidator.ts
@@ -1,6 +1,6 @@
 import { ApiResponseValidator } from '../../src/validation/ApiResponseValidator';
 import { ApiResponse } from '../../src/models/answersapi/ApiResponse';
-import { AnswersError } from '../../src/models/answersapi/AnswersError';
+import { SearchError } from '../../src/models/answersapi/SearchError';
 
 const apiResponseValidator = new ApiResponseValidator();
 
@@ -26,7 +26,7 @@ it('A response without a response property fails validation', () => {
   } as ApiResponse;
   const validationResponse = apiResponseValidator.validate(response);
 
-  return expect(validationResponse).toBeInstanceOf(AnswersError);
+  return expect(validationResponse).toBeInstanceOf(SearchError);
 });
 
 it('A response without a meta property fails validation', () => {
@@ -35,7 +35,7 @@ it('A response without a meta property fails validation', () => {
   } as ApiResponse;
   const validationResponse = apiResponseValidator.validate(response);
 
-  return expect(validationResponse).toBeInstanceOf(AnswersError);
+  return expect(validationResponse).toBeInstanceOf(SearchError);
 });
 
 it('A response with an error fails validation', () => {
@@ -54,5 +54,5 @@ it('A response with an error fails validation', () => {
   };
   const validationResponse = apiResponseValidator.validate(response);
 
-  return expect(validationResponse).toBeInstanceOf(AnswersError);
+  return expect(validationResponse).toBeInstanceOf(SearchError);
 });


### PR DESCRIPTION
Rename the following interfaces:
AnswersRequest -> SearchRequest
AnswersError -> SearchError
AnswersCore -> SearchCore