### PR TITLE
Make Result a generic

### DIFF
--- a/docs/search-core.result.entitytype.md
+++ b/docs/search-core.result.entitytype.md
@@ -4,7 +4,7 @@
 
 ## Result.entityType property
 
-The entity type of the result
+The entity type of the result.
 
 <b>Signature:</b>
 

--- a/docs/search-core.result.md
+++ b/docs/search-core.result.md
@@ -9,7 +9,7 @@ An individual search result.
 <b>Signature:</b>
 
 ```typescript
-export interface Result 
+export interface Result<T = Record<string, unknown>> 
 ```
 
 ## Properties
@@ -19,12 +19,12 @@ export interface Result
 |  [description?](./search-core.result.description.md) | string | <i>(Optional)</i> A description of the result. |
 |  [distance?](./search-core.result.distance.md) | number | <i>(Optional)</i> The distance from the user to the result in meters. |
 |  [distanceFromFilter?](./search-core.result.distancefromfilter.md) | number | <i>(Optional)</i> The distance from a [AppliedQueryFilter](./search-core.appliedqueryfilter.md) location to the result in meters. |
-|  [entityType?](./search-core.result.entitytype.md) | string | <i>(Optional)</i> The entity type of the result |
+|  [entityType?](./search-core.result.entitytype.md) | string | <i>(Optional)</i> The entity type of the result. |
 |  [highlightedFields?](./search-core.result.highlightedfields.md) | [HighlightedFields](./search-core.highlightedfields.md) | <i>(Optional)</i> The [highlighted fields](./search-core.highlightedfields.md) emphasized by the api. |
 |  [id?](./search-core.result.id.md) | string | <i>(Optional)</i> The result ID which depends on the Result Source. |
 |  [index?](./search-core.result.index.md) | number | <i>(Optional)</i> The index of the result among the other results in the search. |
 |  [link?](./search-core.result.link.md) | string | <i>(Optional)</i> A hyperlink associated with the result. |
 |  [name?](./search-core.result.name.md) | string | <i>(Optional)</i> The name of the result. |
-|  [rawData](./search-core.result.rawdata.md) | Record&lt;string, unknown&gt; | Raw entity profile data in the shape of key-value pairs. |
+|  [rawData](./search-core.result.rawdata.md) | T | Raw entity profile data in the shape of key-value pairs. |
 |  [source](./search-core.result.source.md) | [Source](./search-core.source.md) | Represents the source of a [Result](./search-core.result.md)<!-- -->. |
 

--- a/docs/search-core.result.rawdata.md
+++ b/docs/search-core.result.rawdata.md
@@ -9,5 +9,5 @@ Raw entity profile data in the shape of key-value pairs.
 <b>Signature:</b>
 
 ```typescript
-rawData: Record<string, unknown>;
+rawData: T;
 ```

--- a/etc/search-core.api.md
+++ b/etc/search-core.api.md
@@ -381,7 +381,7 @@ export interface QuestionSubmissionService {
 }
 
 // @public
-export interface Result {
+export interface Result<T = Record<string, unknown>> {
     description?: string;
     distance?: number;
     distanceFromFilter?: number;
@@ -391,7 +391,7 @@ export interface Result {
     index?: number;
     link?: string;
     name?: string;
-    rawData: Record<string, unknown>;
+    rawData: T;
     source: Source;
 }
 

--- a/src/models/searchservice/response/Result.ts
+++ b/src/models/searchservice/response/Result.ts
@@ -6,10 +6,10 @@ import { Source } from './Source';
  *
  * @public
  */
-export interface Result {
+export interface Result<T = Record<string, unknown>> {
   /** Raw entity profile data in the shape of key-value pairs. */
-  rawData: Record<string, unknown>,
-  /** {@inheritDoc Source}*/
+  rawData: T,
+  /** {@inheritDoc Source} */
   source: Source,
   /** The index of the result among the other results in the search. */
   index?: number,
@@ -38,6 +38,6 @@ export interface Result {
   distanceFromFilter?: number,
   /** The {@link HighlightedFields | highlighted fields} emphasized by the api. */
   highlightedFields?: HighlightedFields,
-  /** The entity type of the result */
+  /** The entity type of the result. */
   entityType?: string
 }


### PR DESCRIPTION
Update `Result` to accept a generic type param that is passed to `rawData`.

J=SLAP-2231
TEST=auto, manual

Check that tests still pass and that the type param is optional. The default value is used unless a type is specified.