### PR TITLE
Update endpoints to use search

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,13 +3,13 @@ import { Endpoints } from './models/core/Endpoints';
 export const defaultApiVersion = 20220511;
 
 export const defaultEndpoints: Required<Endpoints> = {
-  universalSearch: 'https://liveapi.yext.com/v2/accounts/me/answers/query',
-  verticalSearch: 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query',
+  universalSearch: 'https://liveapi.yext.com/v2/accounts/me/search/query',
+  verticalSearch: 'https://liveapi.yext.com/v2/accounts/me/search/vertical/query',
   questionSubmission: 'https://liveapi.yext.com/v2/accounts/me/createQuestion',
   status: 'https://answersstatus.pagescdn.com',
-  universalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/answers/autocomplete',
-  verticalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/answers/vertical/autocomplete',
-  filterSearch: 'https://liveapi-cached.yext.com/v2/accounts/me/answers/filtersearch',
+  universalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/search/autocomplete',
+  verticalAutocomplete: 'https://liveapi-cached.yext.com/v2/accounts/me/search/vertical/autocomplete',
+  filterSearch: 'https://liveapi-cached.yext.com/v2/accounts/me/search/filtersearch',
 } as const;
 
 /**
@@ -18,11 +18,11 @@ export const defaultEndpoints: Required<Endpoints> = {
  * @public
  */
 export const SandboxEndpoints: Required<Endpoints> = {
-  universalSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/answers/query',
-  verticalSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/answers/vertical/query',
+  universalSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/search/query',
+  verticalSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/search/vertical/query',
   questionSubmission: 'https://liveapi-sandbox.yext.com/v2/accounts/me/createQuestion',
   status: 'https://answersstatus.pagescdn.com',
-  universalAutocomplete: 'https://liveapi-sandbox.yext.com/v2/accounts/me/answers/autocomplete',
-  verticalAutocomplete: 'https://liveapi-sandbox.yext.com/v2/accounts/me/answers/vertical/autocomplete',
-  filterSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/answers/filtersearch',
+  universalAutocomplete: 'https://liveapi-sandbox.yext.com/v2/accounts/me/search/autocomplete',
+  verticalAutocomplete: 'https://liveapi-sandbox.yext.com/v2/accounts/me/search/vertical/autocomplete',
+  filterSearch: 'https://liveapi-sandbox.yext.com/v2/accounts/me/search/filtersearch',
 } as const;

--- a/tests/infra/SearchServiceImpl.ts
+++ b/tests/infra/SearchServiceImpl.ts
@@ -74,7 +74,7 @@ describe('SearchService', () => {
   });
 
   describe('Universal Search', () => {
-    const expectedUniversalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/query';
+    const expectedUniversalUrl = 'https://liveapi.yext.com/v2/accounts/me/search/query';
 
     it('Query params are correct when only required params (without token) are supplied', async () => {
       const requestWithRequiredParams: UniversalSearchRequest = {
@@ -200,7 +200,7 @@ describe('SearchService', () => {
   });
 
   describe('Vertical Search', () => {
-    const expectedVerticalUrl = 'https://liveapi.yext.com/v2/accounts/me/answers/vertical/query';
+    const expectedVerticalUrl = 'https://liveapi.yext.com/v2/accounts/me/search/vertical/query';
 
     it('Query params are correct when only required params (without token) are supplied', async () => {
       const requestWithRequiredParams: VerticalSearchRequest = {


### PR DESCRIPTION
Our endpoints [still have answers](https://yext.slack.com/archives/C032CKFARGS/p1659549401958919) in their links after the rebranding, so this PR updates them to use search.  

J=SLAP-2293
TEST=auto, manual

Unit tests were updated to use search instead of answers: all pass.  The test site was used to check that all API responses remained functional.  It was verified that "search" was correctly shown in the API response URL.
