### PR TITLE
bump alpha to deprecate re-exports in headless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.0.0-alpha.215",
+  "version": "2.0.0-alpha.218",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.0.0-alpha.215",
+      "version": "2.0.0-alpha.218",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.0.0-alpha.215",
+  "version": "2.0.0-alpha.218",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",


### PR DESCRIPTION
This PR bump alpha after removing all deprecated code. After new version is published, it will prompt error for deprecated re-exports that needs removal in headless.