### PR TITLE
Allow Webpack & Rollup to tree-shake Core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@yext/search-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/bundle.d.ts",
+  "sideEffects": false,
   "keywords": [
     "networking",
     "search api",


### PR DESCRIPTION
This PR adds `"sideEffects": false` to the package.json. This flag lets Webpack & Rollup know that search-core is safe to tree-shake. Prior to this change, a PagesJS user was seeing the entirety of Core included in their bundles, even though they were only using a small part of its exported functionality.