### PR TITLE
v2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@yext/search-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/bundle.d.ts",
+  "sideEffects": false,
   "keywords": [
     "networking",
     "search api",


### PR DESCRIPTION
## Version 2.3.1
###Fixes 
- Adds `"sideEffects": false` to the `package.json`. This ensures that Rollup & Webpack can properly tree-shake Core when used in other applications. (#239)