### PR TITLE
Remove rawData array type

### DIFF
--- a/docs/search-core.result.md
+++ b/docs/search-core.result.md
@@ -27,7 +27,7 @@ export interface Result<T = Record<string, unknown>>
 |  [index?](./search-core.result.index.md) | number | <i>(Optional)</i> The index of the result among the other results in the search. |
 |  [link?](./search-core.result.link.md) | string | <i>(Optional)</i> A hyperlink associated with the result. |
 |  [name?](./search-core.result.name.md) | string | <i>(Optional)</i> The name of the result. |
-|  [rawData](./search-core.result.rawdata.md) | T \| T\[\] | Raw entity profile data in the shape of key-value pairs, or as an array of key-value pairs. |
+|  [rawData](./search-core.result.rawdata.md) | T | Raw entity profile data in the shape of key-value pairs, or as an array of key-value pairs. |
 |  [segment?](./search-core.result.segment.md) | [Segment](./search-core.segment.md) | <i>(Optional)</i> A relevant segment associated with the result. Present for document verticals grouped by Segment. |
 |  [source](./search-core.result.source.md) | [Source](./search-core.source.md) | Represents the source of a [Result](./search-core.result.md)<!-- -->. |
 

--- a/docs/search-core.result.rawdata.md
+++ b/docs/search-core.result.rawdata.md
@@ -9,5 +9,5 @@ Raw entity profile data in the shape of key-value pairs, or as an array of key-v
 <b>Signature:</b>
 
 ```typescript
-rawData: T | T[];
+rawData: T;
 ```

--- a/etc/search-core.api.md
+++ b/etc/search-core.api.md
@@ -608,7 +608,7 @@ export interface Result<T = Record<string, unknown>> {
     index?: number;
     link?: string;
     name?: string;
-    rawData: T | T[];
+    rawData: T;
     segment?: Segment;
     source: Source;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.5.0-beta.2",
+      "version": "2.5.0-beta.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/models/searchservice/response/Result.ts
+++ b/src/models/searchservice/response/Result.ts
@@ -10,7 +10,7 @@ import { DocumentResult } from './DocumentResult';
  */
 export interface Result<T = Record<string, unknown>> {
   /** Raw entity profile data in the shape of key-value pairs, or as an array of key-value pairs. */
-  rawData: T | T[],
+  rawData: T,
   /** {@inheritDoc Source} */
   source: Source,
   /** The index of the result among the other results in the search. */


### PR DESCRIPTION
It turns out this change was unnecessary because someone could pass an array as the generic

J=BACK-2523
TEST=compile