### PR TITLE
make `queryDurationMillis` field optional in VerticalResults

### DIFF
--- a/docs/search-core.verticalresults.md
+++ b/docs/search-core.verticalresults.md
@@ -17,7 +17,7 @@ export interface VerticalResults
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appliedQueryFilters](./search-core.verticalresults.appliedqueryfilters.md) | [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->\[\] | A array of [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->s which were applied to the vertical results. |
-|  [queryDurationMillis?](./search-core.verticalresults.querydurationmillis.md) | number | <i>(Optional)</i> The duration of the query in milliseconds (this is present in a universal search but not in a vertical search). |
+|  [queryDurationMillis?](./search-core.verticalresults.querydurationmillis.md) | number | <i>(Optional)</i> The duration of the query in milliseconds |
 |  [results](./search-core.verticalresults.results.md) | [Result](./search-core.result.md)<!-- -->\[\] | An array of search [Result](./search-core.result.md)<!-- -->s for the vertical. |
 |  [resultsCount](./search-core.verticalresults.resultscount.md) | number | The total number of results within the vertical. |
 |  [source](./search-core.verticalresults.source.md) | [Source](./search-core.source.md) | Represents the source of a [Result](./search-core.result.md)<!-- -->. |

--- a/docs/search-core.verticalresults.md
+++ b/docs/search-core.verticalresults.md
@@ -17,7 +17,7 @@ export interface VerticalResults
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appliedQueryFilters](./search-core.verticalresults.appliedqueryfilters.md) | [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->\[\] | A array of [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->s which were applied to the vertical results. |
-|  [queryDurationMillis](./search-core.verticalresults.querydurationmillis.md) | number | The duration of the query in milliseconds. |
+|  [queryDurationMillis?](./search-core.verticalresults.querydurationmillis.md) | number | <i>(Optional)</i> The duration of the query in milliseconds. |
 |  [results](./search-core.verticalresults.results.md) | [Result](./search-core.result.md)<!-- -->\[\] | An array of search [Result](./search-core.result.md)<!-- -->s for the vertical. |
 |  [resultsCount](./search-core.verticalresults.resultscount.md) | number | The total number of results within the vertical. |
 |  [source](./search-core.verticalresults.source.md) | [Source](./search-core.source.md) | Represents the source of a [Result](./search-core.result.md)<!-- -->. |

--- a/docs/search-core.verticalresults.md
+++ b/docs/search-core.verticalresults.md
@@ -17,7 +17,7 @@ export interface VerticalResults
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [appliedQueryFilters](./search-core.verticalresults.appliedqueryfilters.md) | [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->\[\] | A array of [AppliedQueryFilter](./search-core.appliedqueryfilter.md)<!-- -->s which were applied to the vertical results. |
-|  [queryDurationMillis?](./search-core.verticalresults.querydurationmillis.md) | number | <i>(Optional)</i> The duration of the query in milliseconds. |
+|  [queryDurationMillis?](./search-core.verticalresults.querydurationmillis.md) | number | <i>(Optional)</i> The duration of the query in milliseconds (this is present in a universal search but not in a vertical search). |
 |  [results](./search-core.verticalresults.results.md) | [Result](./search-core.result.md)<!-- -->\[\] | An array of search [Result](./search-core.result.md)<!-- -->s for the vertical. |
 |  [resultsCount](./search-core.verticalresults.resultscount.md) | number | The total number of results within the vertical. |
 |  [source](./search-core.verticalresults.source.md) | [Source](./search-core.source.md) | Represents the source of a [Result](./search-core.result.md)<!-- -->. |

--- a/docs/search-core.verticalresults.querydurationmillis.md
+++ b/docs/search-core.verticalresults.querydurationmillis.md
@@ -9,5 +9,5 @@ The duration of the query in milliseconds.
 <b>Signature:</b>
 
 ```typescript
-queryDurationMillis: number;
+queryDurationMillis?: number;
 ```

--- a/docs/search-core.verticalresults.querydurationmillis.md
+++ b/docs/search-core.verticalresults.querydurationmillis.md
@@ -4,10 +4,15 @@
 
 ## VerticalResults.queryDurationMillis property
 
-The duration of the query in milliseconds (this is present in a universal search but not in a vertical search).
+The duration of the query in milliseconds
 
 <b>Signature:</b>
 
 ```typescript
 queryDurationMillis?: number;
 ```
+
+## Remarks
+
+This is present in a universal search but not in a vertical search.
+

--- a/docs/search-core.verticalresults.querydurationmillis.md
+++ b/docs/search-core.verticalresults.querydurationmillis.md
@@ -4,7 +4,7 @@
 
 ## VerticalResults.queryDurationMillis property
 
-The duration of the query in milliseconds.
+The duration of the query in milliseconds (this is present in a universal search but not in a vertical search).
 
 <b>Signature:</b>
 

--- a/etc/search-core.api.md
+++ b/etc/search-core.api.md
@@ -858,7 +858,7 @@ export interface VerticalAutocompleteRequest extends SearchRequest {
 // @public
 export interface VerticalResults {
     appliedQueryFilters: AppliedQueryFilter[];
-    queryDurationMillis: number;
+    queryDurationMillis?: number;
     results: Result[];
     resultsCount: number;
     source: Source;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.6.0-beta",
+  "version": "2.6.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.6.0-beta",
+      "version": "2.6.0-beta.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.6.0-beta",
+  "version": "2.6.0-beta.2",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/models/searchservice/response/VerticalResults.ts
+++ b/src/models/searchservice/response/VerticalResults.ts
@@ -11,7 +11,7 @@ export interface VerticalResults {
   /** A array of {@link AppliedQueryFilter}s which were applied to the vertical results. */
   appliedQueryFilters: AppliedQueryFilter[],
   /** The duration of the query in milliseconds. */
-  queryDurationMillis: number,
+  queryDurationMillis?: number,
   /** An array of search {@link Result}s for the vertical. */
   results: Result[],
   /**

--- a/src/models/searchservice/response/VerticalResults.ts
+++ b/src/models/searchservice/response/VerticalResults.ts
@@ -10,7 +10,7 @@ import { Source } from './Source';
 export interface VerticalResults {
   /** A array of {@link AppliedQueryFilter}s which were applied to the vertical results. */
   appliedQueryFilters: AppliedQueryFilter[],
-  /** The duration of the query in milliseconds. */
+  /** The duration of the query in milliseconds (this is present in a universal search but not in a vertical search). */
   queryDurationMillis?: number,
   /** An array of search {@link Result}s for the vertical. */
   results: Result[],

--- a/src/models/searchservice/response/VerticalResults.ts
+++ b/src/models/searchservice/response/VerticalResults.ts
@@ -10,7 +10,11 @@ import { Source } from './Source';
 export interface VerticalResults {
   /** A array of {@link AppliedQueryFilter}s which were applied to the vertical results. */
   appliedQueryFilters: AppliedQueryFilter[],
-  /** The duration of the query in milliseconds (this is present in a universal search but not in a vertical search). */
+  /** The duration of the query in milliseconds
+   *
+   * @remarks
+   * This is present in a universal search but not in a vertical search.
+  */
   queryDurationMillis?: number,
   /** An array of search {@link Result}s for the vertical. */
   results: Result[],

--- a/tests/infra/GenerativeDirectAnswerServiceImpl.ts
+++ b/tests/infra/GenerativeDirectAnswerServiceImpl.ts
@@ -14,7 +14,6 @@ const defaultEndpoints: Required<Endpoints> = new EndpointsFactory().getEndpoint
 
 const mockVerticalResults = [{
   'appliedQueryFilters': [],
-  'queryDurationMillis': 141,
   'results': [
     {
       'distance': 608,
@@ -142,28 +141,31 @@ it('additionalQueryParams are passed through', async () => {
   }));
 });
 
-const mockUniversalResults = [mockVerticalResults, {
-  'appliedQueryFilters': [],
-  'queryDurationMillis': 313,
-  'results': [
-    {
-      'id': '4038721755206544552',
-      'index': 3,
-      'name': 'How do I create a Very Special Event?',
-      'rawData': {
+const mockUniversalResults = [
+  { ...mockVerticalResults, 'queryDurationMillis': 141 },
+  {
+    'appliedQueryFilters': [],
+    'queryDurationMillis': 313,
+    'results': [
+      {
         'id': '4038721755206544552',
+        'index': 3,
         'name': 'How do I create a Very Special Event?',
-        'question': 'How do I create a Very Special Event?',
-        'type': 'faq',
-        'uid': '8367352'
-      },
-      'source': 'CUSTOM_SEARCHER'
-    }
-  ],
-  'resultsCount': 1,
-  'source': 'DOCUMENT_VERTICAL',
-  'verticalKey': 'faq_vector'
-}];
+        'rawData': {
+          'id': '4038721755206544552',
+          'name': 'How do I create a Very Special Event?',
+          'question': 'How do I create a Very Special Event?',
+          'type': 'faq',
+          'uid': '8367352'
+        },
+        'source': 'CUSTOM_SEARCHER'
+      }
+    ],
+    'resultsCount': 1,
+    'source': 'DOCUMENT_VERTICAL',
+    'verticalKey': 'faq_vector'
+  }
+];
 
 const gdaRequestUniversalResults: GenerativeDirectAnswerRequest = {
   searchId: 'testSeachId',


### PR DESCRIPTION
J=CLIP-1318
TEST=auto,manual

ran `npm run test`. Tested this change together with the rest of the sdk changes to confirm that gda is executed successfully after executeVerticalQuery finishes.