### PR TITLE
ksearch: remove Zendesk/Algolia/Bing

### DIFF
--- a/docs/search-core.source.md
+++ b/docs/search-core.source.md
@@ -16,11 +16,8 @@ export declare enum Source
 
 |  Member | Value | Description |
 |  --- | --- | --- |
-|  Algolia | <code>&quot;ALGOLIA&quot;</code> | The result is from Algolia. |
-|  Bing | <code>&quot;BING_CSE&quot;</code> | The result is from Bing Search Engine. |
 |  Custom | <code>&quot;CUSTOM_SEARCHER&quot;</code> | The result was from a custom source. |
 |  DocumentVertical | <code>&quot;DOCUMENT_VERTICAL&quot;</code> | The result is from a document vertical. |
 |  Google | <code>&quot;GOOGLE_CSE&quot;</code> | The result is from Google Custom Search Engine. |
 |  KnowledgeManager | <code>&quot;KNOWLEDGE_MANAGER&quot;</code> | The result is from a Knowledge Graph. |
-|  Zendesk | <code>&quot;ZENDESK&quot;</code> | The result is from Zendesk. |
 

--- a/etc/search-core.api.md
+++ b/etc/search-core.api.md
@@ -728,13 +728,10 @@ export enum SortType {
 
 // @public
 export enum Source {
-    Algolia = "ALGOLIA",
-    Bing = "BING_CSE",
     Custom = "CUSTOM_SEARCHER",
     DocumentVertical = "DOCUMENT_VERTICAL",
     Google = "GOOGLE_CSE",
-    KnowledgeManager = "KNOWLEDGE_MANAGER",
-    Zendesk = "ZENDESK"
+    KnowledgeManager = "KNOWLEDGE_MANAGER"
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/models/searchservice/response/Source.ts
+++ b/src/models/searchservice/response/Source.ts
@@ -8,12 +8,6 @@ export enum Source {
   KnowledgeManager = 'KNOWLEDGE_MANAGER',
   /** The result is from Google Custom Search Engine. */
   Google = 'GOOGLE_CSE',
-  /** The result is from Bing Search Engine. */
-  Bing = 'BING_CSE',
-  /** The result is from Zendesk. */
-  Zendesk = 'ZENDESK',
-  /** The result is from Algolia. */
-  Algolia = 'ALGOLIA',
   /** The result was from a custom source. */
   Custom = 'CUSTOM_SEARCHER',
   /** The result is from a document vertical. */

--- a/src/transformers/searchservice/ResultsFactory.ts
+++ b/src/transformers/searchservice/ResultsFactory.ts
@@ -18,12 +18,6 @@ export class ResultsFactory {
           return this.fromKnowledgeManager(result, resultIndex);
         case Source.Google:
           return this.fromGoogleCustomSearchEngine(result, resultIndex);
-        case Source.Bing:
-          return this.fromBingCustomSearchEngine(result, resultIndex);
-        case Source.Zendesk:
-          return this.fromZendeskSearchEngine(result, resultIndex);
-        case Source.Algolia:
-          return this.fromAlgoliaSearchEngine(result, resultIndex);
         case Source.DocumentVertical:
           return this.fromDocumentVertical(result, resultIndex);
         default:
@@ -74,41 +68,6 @@ export class ResultsFactory {
       name: rawData.htmlTitle.replace(/(<([^>]+)>)/ig, ''),
       description: rawData.htmlSnippet,
       link: rawData.link
-    };
-  }
-
-  private static fromBingCustomSearchEngine(result: any, index: number): Result {
-    const rawData = result.data ?? result;
-    return {
-      rawData: rawData,
-      source: Source.Bing,
-      index: index,
-      name: rawData.name,
-      description: rawData.snippet,
-      link: rawData.url
-    };
-  }
-
-  private static fromZendeskSearchEngine(result: any, index: number): Result {
-    const rawData = result.data ?? result;
-    return {
-      rawData: rawData,
-      source: Source.Zendesk,
-      index: index,
-      name: rawData.title,
-      description: rawData.snippet,
-      link: rawData.html_url
-    };
-  }
-
-  private static fromAlgoliaSearchEngine(result: any, index: number): Result {
-    const rawData = result.data ?? result;
-    return {
-      rawData: rawData,
-      source: Source.Algolia,
-      index: index,
-      name: rawData.name,
-      id: rawData.objectID
     };
   }
 

--- a/tests/transformers/searchservice/ResultsFactory.ts
+++ b/tests/transformers/searchservice/ResultsFactory.ts
@@ -42,59 +42,6 @@ it('properly transforms Knowledge Graph results', () => {
   expect(expectedResults).toMatchObject(actualResults);
 });
 
-it('properly transforms Zendesk results', () => {
-  const zendeskData = [{
-    html_url: 'https://help.yext.com/',
-    id: 8273729837,
-    snippet: 'Enter the Preview link into the text box.',
-    title: 'Add Custom Schema.org Markup',
-  }];
-
-  const expectedResults = [{
-    description: 'Enter the Preview link into the text box.',
-    index: 1,
-    link: 'https://help.yext.com/',
-    name: 'Add Custom Schema.org Markup',
-    rawData: {
-      html_url: 'https://help.yext.com/',
-      id: 8273729837,
-      snippet: 'Enter the Preview link into the text box.',
-      title: 'Add Custom Schema.org Markup',
-    },
-    source: 'ZENDESK',
-  }];
-
-  const actualResults = ResultsFactory.create(zendeskData, Source.Zendesk);
-  expect(expectedResults).toMatchObject(actualResults);
-});
-
-it('properly transforms Algolia results', () => {
-  const algoliaData = [{
-    location: 'Atlanta',
-    logoUrl: 'Hawks_Atlanta.gif',
-    name: 'Hawks',
-    objectID: '49688642',
-    score: 595.5714285714286
-  }];
-
-  const expectedResults = [{
-    id: '49688642',
-    index: 1,
-    name: 'Hawks',
-    rawData: {
-      location: 'Atlanta',
-      logoUrl: 'Hawks_Atlanta.gif',
-      name: 'Hawks',
-      objectID: '49688642',
-      score: 595.5714285714286,
-    },
-    source: 'ALGOLIA',
-  }];
-
-  const actualResults = ResultsFactory.create(algoliaData, Source.Algolia);
-  expect(expectedResults).toMatchObject(actualResults);
-});
-
 it('properly transforms Google Custom Search results', () => {
   const googleData = [{
     displayLink: 'www.yext.com',
@@ -118,32 +65,6 @@ it('properly transforms Google Custom Search results', () => {
   }];
 
   const actualResults = ResultsFactory.create(googleData, Source.Google);
-  expect(expectedResults).toMatchObject(actualResults);
-});
-
-it('properly transforms Bing search results', () => {
-  const bingData = [{
-    displayUrl: 'www.yext.com/support',
-    name: 'Yext support',
-    snippet: 'Get help from Yext',
-    url: 'http://www.yext.com/support'
-  }];
-
-  const expectedResults = [{
-    description: 'Get help from Yext',
-    index: 1,
-    link: 'http://www.yext.com/support',
-    name: 'Yext support',
-    rawData: {
-      displayUrl: 'www.yext.com/support',
-      name: 'Yext support',
-      snippet: 'Get help from Yext',
-      url: 'http://www.yext.com/support',
-    },
-    source: 'BING_CSE',
-  }];
-
-  const actualResults = ResultsFactory.create(bingData, Source.Bing);
   expect(expectedResults).toMatchObject(actualResults);
 });
 


### PR DESCRIPTION
These three backend types are no longer used/supported, so this PR removes them and their associated code.

J=WAT-4331
TEST=auto

Updated and ran tests