### PR TITLE
search-core: add cloudChoice enum and config support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/models/core/CloudChoice.ts
+++ b/src/models/core/CloudChoice.ts
@@ -1,0 +1,9 @@
+/**
+ * Defines the cloud choice of the API domains.
+ *
+ * @public
+ */
+export enum CloudChoice {
+    GLOBAL_MULTI = 'GLOBAL-MULTI', //All available cloud regions
+    GLOBAL_GCP = 'GLOBAL-GCP', //Only available GCP-backed cloud regions
+}

--- a/src/models/core/SearchConfig.ts
+++ b/src/models/core/SearchConfig.ts
@@ -2,6 +2,7 @@ import { Endpoints } from './Endpoints';
 import { Visitor } from './Visitor';
 import { Environment } from './Environment';
 import { CloudRegion } from './CloudRegion';
+import {CloudChoice} from "./CloudChoice";
 
 /**
  * The configuration options for getting the endpoints.
@@ -20,7 +21,13 @@ export interface ServingConfig {
    *
    * @public
    */
-  cloudRegion?: CloudRegion
+  cloudRegion?: CloudRegion,
+  /**
+   * {@inheritDoc CloudChoice}
+   *
+   * @public
+   */
+  cloudChoice?: CloudChoice
 }
 
 /**

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -18,6 +18,7 @@ export {
 } from './core/AdditionalHttpHeaders';
 export { Environment } from './core/Environment';
 export { CloudRegion } from './core/CloudRegion';
+export { CloudChoice } from './core/CloudChoice';
 
 // Autocomplete service
 export * from './autocompleteservice/AutocompleteRequest';

--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -1,7 +1,8 @@
-import { Endpoints } from './models/core/Endpoints';
-import { Environment } from './models/core/Environment';
-import { CloudRegion } from './models/core/CloudRegion';
-import { ServingConfig } from './models/core/SearchConfig';
+import {Endpoints} from './models/core/Endpoints';
+import {Environment} from './models/core/Environment';
+import {CloudRegion} from './models/core/CloudRegion';
+import {ServingConfig} from './models/core/SearchConfig';
+import {CloudChoice} from "./models/core/CloudChoice";
 
 export const defaultApiVersion = 20220511;
 
@@ -13,15 +14,18 @@ export const defaultApiVersion = 20220511;
 export class EndpointsFactory {
   private readonly environment: Environment;
   private readonly cloudRegion: CloudRegion;
+  private readonly cloudChoice: CloudChoice;
 
   constructor(config?: ServingConfig) {
     this.environment = config?.environment || Environment.PROD;
     this.cloudRegion = config?.cloudRegion || CloudRegion.US;
+    this.cloudChoice = config?.cloudChoice || CloudChoice.GLOBAL_MULTI;
   }
 
   /** Provides the domain based on environment and cloud region. */
   getDomain() {
-    return `https://${this.environment}-cdn.${this.cloudRegion}.yextapis.com`;
+    const cloudChoiceSuffix = this.cloudChoice === CloudChoice.GLOBAL_GCP ? '-gcp' : '';
+    return `https://${this.environment}-cdn${cloudChoiceSuffix}.${this.cloudRegion}.yextapis.com`;
   }
 
   /** Provides all endpoints based on environment and cloud region. */
@@ -46,5 +50,5 @@ export class EndpointsFactory {
  * @public
  */
 export const SandboxEndpoints: Required<Endpoints> =
-  new EndpointsFactory({ environment: Environment.SANDBOX, cloudRegion: CloudRegion.US })
+  new EndpointsFactory({ environment: Environment.SANDBOX, cloudRegion: CloudRegion.US, cloudChoice: CloudChoice.GLOBAL_MULTI })
     .getEndpoints();

--- a/tests/provideEndpointsTest.ts
+++ b/tests/provideEndpointsTest.ts
@@ -1,0 +1,47 @@
+import {EndpointsFactory} from '../src/provideEndpoints';
+import {CloudChoice, CloudRegion, Environment} from "../src";
+
+it('Sandbox, US, Multi produces expected endpoint', () => {
+    const endPoints = new EndpointsFactory({
+        environment: Environment.SANDBOX,
+        cloudRegion: CloudRegion.US,
+        cloudChoice: CloudChoice.GLOBAL_MULTI
+    }).getEndpoints();
+    expect(endPoints).toHaveProperty('universalSearch', 'https://sbx-cdn.us.yextapis.com/v2/accounts/me/search/query');
+});
+
+it('Prod, US, Multi produces expected endpoint', () => {
+    const endPoints = new EndpointsFactory({
+        environment: Environment.PROD,
+        cloudRegion: CloudRegion.US,
+        cloudChoice: CloudChoice.GLOBAL_MULTI
+    }).getEndpoints();
+    expect(endPoints).toHaveProperty('verticalSearch', 'https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query');
+});
+
+it('Prod, US, GCP produces expected endpoint', () => {
+    const endPoints = new EndpointsFactory({
+        environment: Environment.PROD,
+        cloudRegion: CloudRegion.US,
+        cloudChoice: CloudChoice.GLOBAL_GCP
+    }).getEndpoints();
+    expect(endPoints).toHaveProperty('universalAutocomplete', 'https://prod-cdn-gcp.us.yextapis.com/v2/accounts/me/search/autocomplete');
+});
+
+it('Prod, EU, Multi produces expected endpoint', () => {
+    const endPoints = new EndpointsFactory({
+        environment: Environment.PROD,
+        cloudRegion: CloudRegion.EU,
+        cloudChoice: CloudChoice.GLOBAL_MULTI
+    }).getEndpoints();
+    expect(endPoints).toHaveProperty('verticalAutocomplete', 'https://prod-cdn.eu.yextapis.com/v2/accounts/me/search/vertical/autocomplete');
+});
+
+it('Prod, EU, GCP produces expected endpoint', () => {
+    const endPoints = new EndpointsFactory({
+        environment: Environment.PROD,
+        cloudRegion: CloudRegion.EU,
+        cloudChoice: CloudChoice.GLOBAL_GCP
+    }).getEndpoints();
+    expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
+});


### PR DESCRIPTION
This PR adds the new cloudChoice config property, to allow choosing either all consumer serving regions, or just the ones backed by GCP. By default the Multi option will be used, so default behavior is unchanged.

J=WAT-4374
TEST=auto

Added new test class