### PR TITLE
Use Cached Endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -26,10 +26,10 @@ export class EndpointsFactory {
   getDomain() {
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
-        return `https://${this.environment}-cdn-gcp.${this.cloudRegion}.yextapis.com`;
+        return `https://${this.environment}-cdn-cached-gcp.${this.cloudRegion}.yextapis.com`;
       case CloudChoice.GLOBAL_MULTI:
       default:
-        return `https://${this.environment}-cdn.${this.cloudRegion}.yextapis.com`;
+        return `https://${this.environment}-cdn-cached.${this.cloudRegion}.yextapis.com`;
     }
   }
 


### PR DESCRIPTION
This change updated the LiveAPI endpoints that search-core provides so that it provides the cached version of the endpoints. Using the cached endpoints helps improve performance.

J=WAT-4442
TEST=manual

Built test site with new change, saw that the cached endpoints were being used.