### PR TITLE
Use Cached Endpoints

### DIFF
--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -26,10 +26,10 @@ export class EndpointsFactory {
   getDomain() {
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
-        return `https://${this.environment}-cdn-gcp.${this.cloudRegion}.yextapis.com`;
+        return `https://${this.environment}-cdn-cached-gcp.${this.cloudRegion}.yextapis.com`;
       case CloudChoice.GLOBAL_MULTI:
       default:
-        return `https://${this.environment}-cdn.${this.cloudRegion}.yextapis.com`;
+        return `https://${this.environment}-cdn-cached.${this.cloudRegion}.yextapis.com`;
     }
   }
 

--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -26,6 +26,17 @@ export class EndpointsFactory {
   getDomain() {
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
+        return `https://${this.environment}-cdn-gcp.${this.cloudRegion}.yextapis.com`;
+      case CloudChoice.GLOBAL_MULTI:
+      default:
+        return `https://${this.environment}-cdn.${this.cloudRegion}.yextapis.com`;
+    }
+  }
+
+  /** Provides the cached domain based on environment and cloud region. */
+  getCachedDomain() {
+    switch (this.cloudChoice){
+      case CloudChoice.GLOBAL_GCP:
         return `https://${this.environment}-cdn-cached-gcp.${this.cloudRegion}.yextapis.com`;
       case CloudChoice.GLOBAL_MULTI:
       default:
@@ -40,8 +51,8 @@ export class EndpointsFactory {
       verticalSearch: `${this.getDomain()}/v2/accounts/me/search/vertical/query`,
       questionSubmission: `${this.getDomain()}/v2/accounts/me/createQuestion`,
       status: 'https://answersstatus.pagescdn.com',
-      universalAutocomplete: `${this.getDomain()}/v2/accounts/me/search/autocomplete`,
-      verticalAutocomplete: `${this.getDomain()}/v2/accounts/me/search/vertical/autocomplete`,
+      universalAutocomplete: `${this.getCachedDomain()}/v2/accounts/me/search/autocomplete`,
+      verticalAutocomplete: `${this.getCachedDomain()}/v2/accounts/me/search/vertical/autocomplete`,
       filterSearch: `${this.getDomain()}/v2/accounts/me/search/filtersearch`,
     };
   }

--- a/tests/provideEndpointsTest.ts
+++ b/tests/provideEndpointsTest.ts
@@ -7,7 +7,7 @@ it('Sandbox, US, Multi produces expected endpoint', () => {
     cloudRegion: CloudRegion.US,
     cloudChoice: CloudChoice.GLOBAL_MULTI
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('universalSearch', 'https://sbx-cdn-cached.us.yextapis.com/v2/accounts/me/search/query');
+  expect(endPoints).toHaveProperty('universalSearch', 'https://sbx-cdn.us.yextapis.com/v2/accounts/me/search/query');
 });
 
 it('Prod, US, Multi produces expected endpoint', () => {
@@ -16,7 +16,7 @@ it('Prod, US, Multi produces expected endpoint', () => {
     cloudRegion: CloudRegion.US,
     cloudChoice: CloudChoice.GLOBAL_MULTI
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('verticalSearch', 'https://prod-cdn-cached.us.yextapis.com/v2/accounts/me/search/vertical/query');
+  expect(endPoints).toHaveProperty('verticalSearch', 'https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query');
 });
 
 it('Prod, US, GCP produces expected endpoint', () => {
@@ -43,5 +43,5 @@ it('Prod, EU, GCP produces expected endpoint', () => {
     cloudRegion: CloudRegion.EU,
     cloudChoice: CloudChoice.GLOBAL_GCP
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-cached-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
+  expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
 });

--- a/tests/provideEndpointsTest.ts
+++ b/tests/provideEndpointsTest.ts
@@ -7,7 +7,7 @@ it('Sandbox, US, Multi produces expected endpoint', () => {
     cloudRegion: CloudRegion.US,
     cloudChoice: CloudChoice.GLOBAL_MULTI
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('universalSearch', 'https://sbx-cdn.us.yextapis.com/v2/accounts/me/search/query');
+  expect(endPoints).toHaveProperty('universalSearch', 'https://sbx-cdn-cached.us.yextapis.com/v2/accounts/me/search/query');
 });
 
 it('Prod, US, Multi produces expected endpoint', () => {
@@ -16,7 +16,7 @@ it('Prod, US, Multi produces expected endpoint', () => {
     cloudRegion: CloudRegion.US,
     cloudChoice: CloudChoice.GLOBAL_MULTI
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('verticalSearch', 'https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query');
+  expect(endPoints).toHaveProperty('verticalSearch', 'https://prod-cdn-cached.us.yextapis.com/v2/accounts/me/search/vertical/query');
 });
 
 it('Prod, US, GCP produces expected endpoint', () => {
@@ -25,7 +25,7 @@ it('Prod, US, GCP produces expected endpoint', () => {
     cloudRegion: CloudRegion.US,
     cloudChoice: CloudChoice.GLOBAL_GCP
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('universalAutocomplete', 'https://prod-cdn-gcp.us.yextapis.com/v2/accounts/me/search/autocomplete');
+  expect(endPoints).toHaveProperty('universalAutocomplete', 'https://prod-cdn-cached-gcp.us.yextapis.com/v2/accounts/me/search/autocomplete');
 });
 
 it('Prod, EU, Multi produces expected endpoint', () => {
@@ -34,7 +34,7 @@ it('Prod, EU, Multi produces expected endpoint', () => {
     cloudRegion: CloudRegion.EU,
     cloudChoice: CloudChoice.GLOBAL_MULTI
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('verticalAutocomplete', 'https://prod-cdn.eu.yextapis.com/v2/accounts/me/search/vertical/autocomplete');
+  expect(endPoints).toHaveProperty('verticalAutocomplete', 'https://prod-cdn-cached.eu.yextapis.com/v2/accounts/me/search/vertical/autocomplete');
 });
 
 it('Prod, EU, GCP produces expected endpoint', () => {
@@ -43,5 +43,5 @@ it('Prod, EU, GCP produces expected endpoint', () => {
     cloudRegion: CloudRegion.EU,
     cloudChoice: CloudChoice.GLOBAL_GCP
   }).getEndpoints();
-  expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
+  expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-cached-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
 });


### PR DESCRIPTION
This change updated the LiveAPI endpoints that search-core provides so that it provides the cached version of the endpoints. Using the cached endpoints helps improve performance.

J=WAT-4442
TEST=manual

Built test site with new change, saw that the cached endpoints were being used.