### PR TITLE
ksearch: drop package version to 2.5.5 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.7",
+  "version": "2.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.5.7",
+      "version": "2.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.5.7",
+  "version": "2.5.5",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",


### PR DESCRIPTION
We have been upping the package version without
cutting releases, so before the next release, this PR drops the version to the next actual version, 2.5.5

J=none
TEST=compile