### PR TITLE
feat: Add DEV/QA options to Environment setting

### DIFF
--- a/docs/search-core.environment.md
+++ b/docs/search-core.environment.md
@@ -32,6 +32,22 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+DEV
+
+
+</td><td>
+
+`"dev"`
+
+
+</td><td>
+
+For internal development only
+
+
+</td></tr>
+<tr><td>
+
 PROD
 
 
@@ -41,6 +57,22 @@ PROD
 
 
 </td><td>
+
+
+</td></tr>
+<tr><td>
+
+QA
+
+
+</td><td>
+
+`"qa"`
+
+
+</td><td>
+
+For internal development only
 
 
 </td></tr>

--- a/etc/search-core.api.md
+++ b/etc/search-core.api.md
@@ -300,8 +300,10 @@ export type EnumOrLiteral<T extends string> = T | `${T}`;
 
 // @public
 export enum Environment {
+    DEV = "dev",
     // (undocumented)
     PROD = "prod",
+    QA = "qa",
     // (undocumented)
     SANDBOX = "sbx"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-core",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Typescript Networking Library for the Yext Search API",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/src/models/core/Environment.ts
+++ b/src/models/core/Environment.ts
@@ -6,4 +6,8 @@
 export enum Environment {
   PROD = 'prod',
   SANDBOX = 'sbx',
+  /** For internal development only */
+  QA = 'qa',
+  /** For internal development only */
+  DEV = 'dev',
 }

--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -24,6 +24,9 @@ export class EndpointsFactory {
 
   /** Provides the domain based on environment and cloud region. */
   getDomain() {
+    if (this.environment === Environment.DEV || this.environment === Environment.QA) {
+      return `https://liveapi-${this.environment}.yext.com`;
+    }
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
         return `https://${this.environment}-cdn-gcp.${this.cloudRegion}.yextapis.com`;
@@ -35,6 +38,9 @@ export class EndpointsFactory {
 
   /** Provides the cached domain based on environment and cloud region. */
   getCachedDomain() {
+    if (this.environment === Environment.DEV || this.environment === Environment.QA) {
+      return this.getDomain();
+    }
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
         return `https://${this.environment}-cdn-cached-gcp.${this.cloudRegion}.yextapis.com`;

--- a/src/provideEndpoints.ts
+++ b/src/provideEndpoints.ts
@@ -24,7 +24,7 @@ export class EndpointsFactory {
 
   /** Provides the domain based on environment and cloud region. */
   getDomain() {
-    if (this.environment === Environment.DEV || this.environment === Environment.QA) {
+    if (this.isInternalTestEnvironment()) {
       return `https://liveapi-${this.environment}.yext.com`;
     }
     switch (this.cloudChoice){
@@ -38,8 +38,8 @@ export class EndpointsFactory {
 
   /** Provides the cached domain based on environment and cloud region. */
   getCachedDomain() {
-    if (this.environment === Environment.DEV || this.environment === Environment.QA) {
-      return this.getDomain();
+    if (this.isInternalTestEnvironment()) {
+      return `https://liveapi-${this.environment}.yext.com`;
     }
     switch (this.cloudChoice){
       case CloudChoice.GLOBAL_GCP:
@@ -62,6 +62,10 @@ export class EndpointsFactory {
       filterSearch: `${this.getDomain()}/v2/accounts/me/search/filtersearch`,
       generativeDirectAnswer: `${this.getDomain()}/v2/accounts/me/search/generateAnswer`,
     };
+  }
+
+  private isInternalTestEnvironment() {
+    return this.environment === Environment.DEV || this.environment === Environment.QA;
   }
 }
 

--- a/tests/provideEndpointsTest.ts
+++ b/tests/provideEndpointsTest.ts
@@ -45,3 +45,21 @@ it('Prod, EU, GCP produces expected endpoint', () => {
   }).getEndpoints();
   expect(endPoints).toHaveProperty('filterSearch', 'https://prod-cdn-gcp.eu.yextapis.com/v2/accounts/me/search/filtersearch');
 });
+
+it('Dev produces expected endpoint', () => {
+  const endPoints = new EndpointsFactory({
+    environment: Environment.DEV,
+    cloudRegion: CloudRegion.US,
+    cloudChoice: CloudChoice.GLOBAL_MULTI
+  }).getEndpoints();
+  expect(endPoints).toHaveProperty('verticalSearch', 'https://liveapi-dev.yext.com/v2/accounts/me/search/vertical/query');
+});
+
+it('QA produces expected endpoint', () => {
+  const endPoints = new EndpointsFactory({
+    environment: Environment.QA,
+    cloudRegion: CloudRegion.US,
+    cloudChoice: CloudChoice.GLOBAL_MULTI
+  }).getEndpoints();
+  expect(endPoints).toHaveProperty('verticalSearch', 'https://liveapi-qa.yext.com/v2/accounts/me/search/vertical/query');
+});


### PR DESCRIPTION
This will allow Yext employees to test the frontend repos in dev/qa, rather than limiting testing to sbx/prod.
Users outside of Yext will not be able to use these environments, as you need to be authenticated via the VPN to access the endpoints.

J=[WAT-4739](https://yexttest.atlassian.net/browse/WAT-4739)
TEST=manual
Daisy-chained local deps from `search-ui-react` to `search-core` and saw local test site working in Dev environment