### PR TITLE
Support trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  id-token: write # Required for OIDC
+
+jobs:
+  publish:
+    if: github.repository == 'yext/search-core'
+    runs-on: ubuntu-latest
+    environment: Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set node version to 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: https://registry.npmjs.org/
+          cache: "npm"
+
+      - name: Install deps
+        run: npm i --ignore-scripts
+
+      - name: Update npm
+        # npm version npm 11.5.1 or later needed for Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Verify package version and get npm tag
+        id: get_npm_tag
+        run: |
+          TAG=$(npm run ci-verify-publish ${{ github.ref_name }} | tail -n 1)
+          echo "npm_tag=$TAG" >> $GITHUB_OUTPUT
+      
+      - name: Debug npm tag
+        run: |
+          echo "npm_tag='${{ steps.get_npm_tag.outputs.npm_tag }}'"
+
+      - name: Publish
+        run: npm publish --access public --tag ${{ steps.get_npm_tag.outputs.npm_tag }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "prepublishOnly": "npm run build",
     "api-extractor": "api-extractor run --local --verbose",
     "generate-docs": "api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp && npm run generate-notices",
-    "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
+    "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite",
+    "ci-verify-publish": "tsx scripts/verifyPublish.ts",
+    "release": "tsx scripts/release.ts",
+    "release:dry": "tsx scripts/release.ts --dry"
   },
   "repository": {
     "type": "git",
@@ -69,10 +72,12 @@
     "eslint": "^8.11.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-tsdoc": "^0.2.14",
+    "execa": "^8.0.1",
     "generate-license-file": "^1.3.0",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "ts-loader": "^8.4.0",
+    "tsx": "^4.6.2",
     "typescript": "^4.0.3",
     "webpack": "^5.90.0",
     "webpack-cli": "^4.4.0"

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,118 @@
+/**
+ * modified from https://github.com/vitejs/vite/blob/main/scripts/release.ts
+ */
+import prompts from 'prompts';
+import semver from 'semver';
+import colors from 'picocolors';
+import {
+  args,
+  getLatestTag,
+  getPackageInfo,
+  getVersionChoices,
+  isDryRun,
+  logRecentCommits,
+  run,
+  runIfNotDry,
+  step,
+  updateVersion,
+} from './releaseUtils.js';
+
+(async () => {
+  let targetVersion: string | undefined;
+
+  const { currentVersion, pkg, pkgPath, pkgDir } = await getPackageInfo();
+
+  const packageName = pkg.name;
+
+  await logRecentCommits(packageName);
+
+  if (!targetVersion) {
+    const { release }: { release: string } = await prompts({
+      type: 'select',
+      name: 'release',
+      message: 'Select release type',
+      choices: getVersionChoices(currentVersion),
+    });
+
+    if (release === 'custom') {
+      const res: { version: string } = await prompts({
+        type: 'text',
+        name: 'version',
+        message: 'Input custom version',
+        initial: currentVersion,
+      });
+      targetVersion = res.version;
+    } else {
+      targetVersion = release;
+    }
+  }
+
+  if (!semver.valid(targetVersion)) {
+    console.error(`invalid target version: ${targetVersion}`);
+    process.exit(1);
+  }
+
+  const tag = `${packageName}@${targetVersion}`;
+
+  if (targetVersion.includes('beta') && !args.tag) {
+    args.tag = 'beta';
+  }
+  if (targetVersion.includes('alpha') && !args.tag) {
+    args.tag = 'alpha';
+  }
+
+  const { yes }: { yes: boolean } = await prompts({
+    type: 'confirm',
+    name: 'yes',
+    message: `Releasing ${colors.yellow(tag)} Confirm?`,
+  });
+
+  if (!yes) {
+    process.exit();
+  }
+
+  step('\nUpdating package version...');
+  updateVersion(pkgDir, pkgPath, targetVersion);
+
+  step('\nGenerating changelog...');
+  const latestTag = await getLatestTag(packageName);
+  if (!latestTag) {
+    step('\nNo previous tag, skipping changelog generation.');
+  } else {
+    const sha = (
+      await run('git', ['rev-list', '-n', '1', latestTag], {
+        stdio: 'pipe',
+      })
+    ).stdout.trim();
+
+    const changelogArgs = ['generate-changelog', `${sha}..HEAD`];
+    await run('npx', changelogArgs, { cwd: pkgDir });
+  }
+
+  const { stdout } = await run('git', ['diff'], { stdio: 'pipe' });
+  if (stdout) {
+    step('\nCommitting changes...');
+    await runIfNotDry('git', ['add', '-A']);
+    await runIfNotDry('git', ['commit', '-m', `release: ${tag}`]);
+    await runIfNotDry('git', ['tag', tag]);
+  } else {
+    console.log('No changes to commit.');
+    process.exit();
+  }
+
+  step('\nPushing to GitHub...');
+  await runIfNotDry('git', ['push', 'origin', `refs/tags/${tag}`]);
+  await runIfNotDry('git', ['push']);
+
+  if (isDryRun) {
+    console.log('\nDry run finished - run git diff to see package changes.');
+  } else {
+    console.log(
+      colors.green(
+        '\nPushed, publishing should starts shortly on CI.\nhttps://github.com/yext/search-core/blob/main/.github/workflows/publish.yml'
+      )
+    );
+  }
+
+  console.log();
+})();

--- a/scripts/releaseUtils.ts
+++ b/scripts/releaseUtils.ts
@@ -1,0 +1,203 @@
+/**
+ * modified from https://github.com/vitejs/vite/blob/main/scripts/releaseUtils.ts
+ */
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import path from 'path';
+import colors from 'picocolors';
+import type { Options as ExecaOptions, ExecaReturnValue } from 'execa';
+import { execa } from 'execa';
+import type { ReleaseType } from 'semver';
+import semver from 'semver';
+import fs from 'fs-extra';
+import minimist from 'minimist';
+import { fileURLToPath } from 'url';
+
+export const args = minimist(process.argv.slice(2));
+
+export const isDryRun = !!args.dry;
+
+if (isDryRun) {
+  console.log(colors.inverse(colors.yellow(' DRY RUN ')));
+  console.log();
+}
+
+export const versionIncrements: ReleaseType[] = ['patch', 'minor', 'major'];
+
+interface Pkg {
+  name: string,
+  version: string,
+  private?: boolean
+}
+export async function getPackageInfo(): Promise<{
+  pkg: Pkg,
+  pkgDir: string,
+  pkgPath: string,
+  currentVersion: string
+}> {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const pkgDir = path.resolve(__dirname, '..');
+
+  const pkgPath = path.resolve(pkgDir, 'package.json');
+  const pkg: Pkg = await import(pkgPath);
+
+  const currentVersion = pkg.version;
+
+  if (pkg.private) {
+    console.error(`Package ${pkg.name} is private`);
+    process.exit(1);
+  }
+
+  return {
+    pkg,
+    pkgDir,
+    pkgPath,
+    currentVersion,
+  };
+}
+
+export async function run(
+  bin: string,
+  args: string[],
+  opts: ExecaOptions<string> = {}
+): Promise<ExecaReturnValue<string>> {
+  return execa(bin, args, { stdio: 'inherit', ...opts });
+}
+
+export async function dryRun(
+  bin: string,
+  args: string[],
+  opts?: ExecaOptions<string>
+): Promise<void> {
+  return console.log(
+    colors.blue(`[dryrun] ${bin} ${args.join(' ')}`),
+    opts || ''
+  );
+}
+
+export const runIfNotDry = isDryRun ? dryRun : run;
+
+export function step(msg: string): void {
+  return console.log(colors.cyan(msg));
+}
+
+interface VersionChoice {
+  title: string,
+  value: string
+}
+export function getVersionChoices(currentVersion: string): VersionChoice[] {
+  const currentBeta = currentVersion.includes('beta');
+  const currentAlpha = currentVersion.includes('alpha');
+  const isStable = !currentBeta && !currentAlpha;
+
+  function inc(i: ReleaseType, tag = currentAlpha ? 'alpha' : 'beta') {
+    const incVersion = semver.inc(currentVersion, i, tag);
+    if (incVersion) {
+      return incVersion;
+    }
+
+    throw new Error('Invalid version');
+  }
+
+  let versionChoices: VersionChoice[] = [
+    {
+      title: 'next',
+      value: inc(isStable ? 'patch' : 'prerelease'),
+    },
+  ];
+
+  if (isStable) {
+    versionChoices.push(
+      {
+        title: 'beta-minor',
+        value: inc('preminor'),
+      },
+      {
+        title: 'beta-major',
+        value: inc('premajor'),
+      },
+      {
+        title: 'alpha-minor',
+        value: inc('preminor', 'alpha'),
+      },
+      {
+        title: 'alpha-major',
+        value: inc('premajor', 'alpha'),
+      },
+      {
+        title: 'minor',
+        value: inc('minor'),
+      },
+      {
+        title: 'major',
+        value: inc('major'),
+      }
+    );
+  } else if (currentAlpha) {
+    versionChoices.push({
+      title: 'beta',
+      value: inc('patch') + '-beta.0',
+    });
+  } else {
+    versionChoices.push({
+      title: 'stable',
+      value: inc('patch'),
+    });
+  }
+  versionChoices.push({ value: 'custom', title: 'custom' });
+
+  versionChoices = versionChoices.map((i) => {
+    i.title = `${i.title} (${i.value})`;
+    return i;
+  });
+
+  return versionChoices;
+}
+
+export function updateVersion(pkgDir: string, pkgPath: string, version: string): void {
+  const pkg = fs.readJSONSync(pkgPath);
+  pkg.version = version;
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+  execSync('npm install', { cwd: pkgDir, stdio: 'inherit' });
+}
+
+export async function getLatestTag(pkgName: string): Promise<string> {
+  const tags = (await run('git', ['tag'], { stdio: 'pipe' })).stdout
+    .split(/\n/)
+    .filter(Boolean);
+  const prefix = `${pkgName}@`;
+  return tags
+    .filter((tag) => tag.startsWith(prefix))
+    .sort()
+    .reverse()[0];
+}
+
+export async function logRecentCommits(pkgName: string): Promise<void> {
+  const tag = await getLatestTag(pkgName);
+  if (!tag) return;
+  const sha = await run('git', ['rev-list', '-n', '1', tag], {
+    stdio: 'pipe',
+  }).then((res) => res.stdout.trim());
+  console.log(
+    colors.bold(
+      `\n${colors.blue('i')} Commits of ${colors.green(
+        pkgName
+      )} since ${colors.green(tag)} ${colors.gray(`(${sha.slice(0, 5)})`)}`
+    )
+  );
+  await run(
+    'git',
+    [
+      '--no-pager',
+      'log',
+      `${sha}..HEAD`,
+      '--oneline',
+      '--',
+      '.',
+    ],
+    { stdio: 'inherit' }
+  );
+  console.log();
+}

--- a/scripts/verifyPublish.ts
+++ b/scripts/verifyPublish.ts
@@ -1,0 +1,40 @@
+import { args, getPackageInfo } from './releaseUtils.js';
+
+(async () => {
+  const tag = args._[0];
+
+  if (!tag) {
+    console.error('No tag specified');
+    process.exit(1);
+  }
+
+  const versionIndex = tag.lastIndexOf('@');
+  const pkgName = tag.slice(0, versionIndex);
+  const version = tag.slice(versionIndex + 1);
+
+  const { pkg, currentVersion } = await getPackageInfo();
+  const packageName = pkg.name;
+  if (pkgName !== packageName) {
+    console.error(
+      `Package name from tag '${pkgName}' mismatches with package '${packageName}'`
+    );
+    process.exit(1);
+  }
+  if (currentVersion !== version) {
+    console.error(
+      `Package version from tag '${version}' mismatches with current version '${currentVersion}'`
+    );
+    process.exit(1);
+  }
+
+  const releaseTag = version.includes('rc')
+    ? 'rc'
+    : version.includes('beta')
+      ? 'beta'
+      : version.includes('alpha')
+        ? 'alpha'
+        : 'latest';
+
+  // Log the release tag to be picked up by the next GitHub Actions step
+  console.log(releaseTag);
+})();


### PR DESCRIPTION
J=WAT-5077
TEST=manual

forked the repo to my personal git account. Verified that:
- the `ci-verify-publish` script output the correct release tag
- the `release` and `release:dry` scripts work as expected on a new patch, minor, major, alpha, beta, and custom version

copied over the relevant changes from the forked repo. Verified that:
- the `ci-verify-publish` script output the correct release tag
- the `release:dry` script make the expected changes locally